### PR TITLE
Fixed error caused by change in jQM 1.3.0

### DIFF
--- a/README
+++ b/README
@@ -11,8 +11,8 @@ Description
 
     The functionality provided by this widget is a workaround for the jQuery Mobile
     loadPage() function which only loads the first page in an AJAX response. You do
-    not use this widget on your initial document load. 
-    
+    not use this widget on your initial document load.
+
 Usage
 
     Add a stack of child div's with data-role="subpage" or data-role="subpage-dialog"
@@ -25,23 +25,23 @@ Notes
     child subpage div's are removed from the DOM.
 
     The functionality provided by this widget is a workaround for the jQuery Mobile
-    loadPage() function which only loads the first page in an AJAX response. 
+    loadPage() function which only loads the first page in an AJAX response.
 
 Demo
 
-    Please visit the http://m.integra-international.net website  to launch the new 
-    Integra Mobile web app which utilizes the subpage widget. After the web app 
-    launches, press the info button on RHS of the header bar. Next select the 
+    Please visit the http://m.integra-international.net website  to launch the new
+    Integra Mobile web app which utilizes the subpage widget. After the web app
+    launches, press the info button on RHS of the header bar. Next select the
     "Integra Mobile" list item. The 'Integra Mobile' page contains a subpage which
     is accessible through the 'About' list item.
 
 Code
 
-    Please note that I define a subpages section ( I use Microsoft MVC Razor views 
+    Please note that I define a subpages section ( I use Microsoft MVC Razor views
     *.cshtml ). This section get inserted at the start of the page div via a .cshtml
     master view.
 
------------------------- 
+------------------------
 
 @{
     ViewBag.Title = "Integra - About";
@@ -61,8 +61,8 @@ Code
         <h2 class="mui-field-title">General</h2>
         <div class="mui-field-inset ui-corner-all ui-shadow">
             <p>
-                Welcome to the new Integra Mobile web app. Use this web app to locate Integra member firms and contacts, 
-                view mergers and acquisitions with our Deal Board or generally learn everything about Integra. We hope you 
+                Welcome to the new Integra Mobile web app. Use this web app to locate Integra member firms and contacts,
+                view mergers and acquisitions with our Deal Board or generally learn everything about Integra. We hope you
                 enjoy using this web app and would like to hear from you with your feedback.
             </p>
         </div>
@@ -75,7 +75,7 @@ Code
         </div>
         <h2 class="mui-field-title">Copyright</h2>
         <div class="mui-field-inset ui-corner-all ui-shadow">
-            
+
             <p>
                 Copyright 2011 Achilles Software. All Rights Reserved.
             </p>
@@ -113,4 +113,9 @@ Code
     </ul>
 </div>
 
- 
+ Change Log
+
+1.1 - 5 March 2013
+
+- Fixed incompatibility with jQueryMobile 1.3.0's change from storing data in .data('page') to .data('mobile-page').
+  The plugin now adapts based on the jQueryMobile version in use.

--- a/jquery.mobile.subpage.js
+++ b/jquery.mobile.subpage.js
@@ -10,7 +10,7 @@
 * http://jquery.org/license
 */
 
-/* 
+/*
  * Tested with dependent libraries:
  *    jQuery Mobile version 1.1
  */
@@ -29,7 +29,7 @@
 *
 *   Subpages are detached from parent page and added/removed to/from the DOM.
 *   The functionality provided by this widget is a workaround for the jQuery Mobile
-*   loadPage() function which only loads the first page in an AJAX response. 
+*   loadPage() function which only loads the first page in an AJAX response.
 */
 
 (function ($, undefined) {
@@ -43,14 +43,24 @@
         },
 
         _create: function () {
-            var t = this;
+            var self = this;
+
+            /*
+             * jQueryMobile changed the name of the data attribute where it stores data with version 1.3.
+             */
+            if ($.mobile.version >= 1.3) {
+                self.jqmDataLabel = 'mobile-page';
+            }
+            else {
+                self.jqmDataLabel = 'page';
+            }
 
             // Subpages may only be defined with pages dynamically loaded via loadPage().
             // Pages loaded this way always have a unique data-url attribute set.
-            this.parentPage = this.element.closest(":jqmData(role='page')");
-            this.parentPageUrl = this.parentPage.jqmData("url");
+            self.parentPage = self.element.closest(":jqmData(role='page')");
+            self.parentPageUrl = self.parentPage.jqmData("url");
 
-            t.element.addClass(function (i, orig) {
+            self.element.addClass(function (i, orig) {
                 return orig + " ui-subpage ";
             });
 
@@ -59,17 +69,17 @@
 
         _createSubPage: function () {
             var self = this,
-                subpage = this.element,
+                subpage = self.element,
                 subpageType = subpage.jqmData("role");
 
             // Subpages should have an id attribute, but we cannot guarentee this.
             // Fallback to the subpage count with the page as the UId
-            if (typeof subpageCountPerPage[this.parentPageUrl] === "undefined") {
-                subpageCountPerPage[this.parentPageUrl] = -1;
+            if (typeof subpageCountPerPage[self.parentPageUrl] === "undefined") {
+                subpageCountPerPage[self.parentPageUrl] = -1;
             }
 
-            var subpageUId = subpage.attr("id") || ++subpageCountPerPage[this.parentPageUrl];
-            var subpageUrl = this.parentPageUrl + "&" + $.mobile.subPageUrlKey + "=" + subpageUId;
+            var subpageUId = subpage.attr("id") || ++subpageCountPerPage[self.parentPageUrl];
+            var subpageUrl = self.parentPageUrl + "&" + $.mobile.subPageUrlKey + "=" + subpageUId;
 
             var newPage = subpage.detach();
 
@@ -95,8 +105,8 @@
 
             // on pagehide, remove any nested pages along with the parent page, as long as they aren't active
             // and aren't embedded
-            if ( this.parentPage.is(":jqmData(external-page='true')") &&
-                 this.parentPage.data("page").options.domCache === false) {
+            if ( self.parentPage.is(":jqmData(external-page='true')") &&
+                 self.parentPage.data(self.jqmDataLabel).options.domCache === false) {
 
                 var subpageRemove = function (e, ui) {
                     var nextPage = ui.nextPage, npURL;
@@ -111,7 +121,7 @@
                 };
 
                 // unbind the original page remove and replace with our specialized version
-                this.parentPage
+                self.parentPage
                     .unbind("pagehide.remove")
                     .bind("pagehide.remove", subpageRemove);
             }


### PR DESCRIPTION
Fixed an error caused by jQM changing the data attribute name for page
data.  Changed to make use of 'self' more consistent.  (There are also
a few whitespace changes caused by my editor trimming trailing white
space.)
